### PR TITLE
Choosing various 1) Google properties & 2) Categories searches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - `gtrends()` will throw a warning if data is returned monthly (#80).
 
+- `gtrends()` is not correctly detecting when quota limit is reached (#90).
+
 # gtrendsR 1.3.3
 
 - A ggplot2 object can now be returned for further customization. `plot(gtrends("NHL")) + ggtitle("NHL trend") + theme(legend.position="none")`

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - `gtrends()` will throw a warning if data is returned monthly (#80).
 
-- `gtrends()` is not correctly detecting when quota limit is reached (#90).
+- `gtrends()` is now correctly detecting when quota limit is reached (#90).
 
 # gtrendsR 1.3.3
 

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -221,7 +221,7 @@ gtrends <- function(query, geo, cat, ch, ...) {
 #' @importFrom utils data
 #' @rdname gtrends
 #' @export
-gtrends.default <- function(query, 
+gtrends.default <- function(query = "", 
                             geo, 
                             cat, 
                             ch, 
@@ -331,7 +331,7 @@ gtrends.default <- function(query,
   
   resultsText <- getForm(trendsURL, .params = pp, curl = ch)
   
-  if (any(grep("QUOTA", resultsText))) {
+  if (any(grep("quota", resultsText, ignore.case = TRUE))) {
     stop("Reached Google Trends quota limit! Please try again later.")
   }
   
@@ -493,8 +493,12 @@ as.zoo.gtrends <- function(x, ...) {
   weeks <- data.frame(date = do.call(rbind, strsplit(trend[, 1], " - ")),
                       stringsAsFactors = FALSE)
   
-  trend <- trend[, mapply(is.numeric, trend), drop = FALSE]
-
+  #trend <- trend[, mapply(is.numeric, trend), drop = FALSE]
+  trend <- trend[, 2:ncol(trend), drop = FALSE]
+  trend <- as.data.frame(lapply(trend,
+                                function(x) as.numeric(gsub("([0-9]+).*$", "\\1", x))))
+  
+  
   # For some reason, the headers returned by Google will be the country names
   # if only 1 keeword is provided. 
   requested_kw <- tolower(trimws(unlist(strsplit(queryparams[1], ","), use.names = FALSE)))
@@ -511,6 +515,8 @@ as.zoo.gtrends <- function(x, ...) {
     
     trend[, missing_kw] <- NA
   }
+  
+  if(length(requested_kw) == 0) {requested_kw = received_kw}
   
   requested_kw <- make.names(requested_kw)
   

--- a/man/gtrends.Rd
+++ b/man/gtrends.Rd
@@ -10,9 +10,9 @@
 \usage{
 gtrends(query, geo, cat, ch, ...)
 
-\method{gtrends}{default}(query, geo, cat, ch, res = c(NA, "1h", "4h", "1d",
-  "7d"), start_date = as.Date("2004-01-01"), end_date = as.Date(Sys.time()),
-  ...)
+\method{gtrends}{default}(query = "", geo, cat, ch, res = c(NA, "1h", "4h",
+  "1d", "7d"), start_date = as.Date("2004-01-01"),
+  end_date = as.Date(Sys.time()), ...)
 
 \method{summary}{gtrends}(object, ...)
 


### PR DESCRIPTION
Two enhancements & 2 logical debugs suggested:
Logical debug:
1) Enabling the choice of country code and country sub-code in the same request
2) Debugged the issue with the 1st top search and recent search being used as a header

Enhancement request
1) Added ability to down category related trends by keeping query blank
2) Adding another queryparam (gprop) which appends a choice of Google Property to the gTrendR 
